### PR TITLE
feat: add setPolylineColors to directions renderer

### DIFF
--- a/MPDirectionsRenderer.ts
+++ b/MPDirectionsRenderer.ts
@@ -129,6 +129,21 @@ export default class MPDirectionsRenderer {
     }
 
     /**
+     * Set the colors of the route polyline.
+     *
+     * Colors are given as hex strings (e.g. "#3071D9").
+     *
+     * @public
+     * @async
+     * @param {string} foregroundColor the primary color (animated polyline)
+     * @param {string} backgroundColor the secondary color (static polyline)
+     * @returns {Promise<void>}
+     */
+    public async setPolylineColors(foregroundColor: string, backgroundColor: string): Promise<void> {
+        await DirectionsRenderer.setPolyLineColors(foregroundColor, backgroundColor);
+    }
+
+    /**
      * Enable/Disable the route end/start label buttons from showing on the route. Default is true
      *
      * @public

--- a/MPDirectionsService.ts
+++ b/MPDirectionsService.ts
@@ -29,7 +29,7 @@ export default class MPDirectionsService {
      * @returns {Promise<MPDirectionsService>}
      */
     public static async create(): Promise<MPDirectionsService> {
-        return DirectionsService.create().then((resolve: string) => new MPDirectionsService(resolve));
+        return DirectionsService.createService().then((resolve: string) => new MPDirectionsService(resolve));
     }
 
     /**


### PR DESCRIPTION
Add MPDirectionsRenderer.setPolylineColors to set the foreground and background route polyline colors via hex strings.

Update MPDirectionsService.create to call the renamed native DirectionsService.createService method.